### PR TITLE
replace "nixFlakes" with "nixVersions.stable"

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,4 +29,4 @@ python3.pkgs.buildPythonApplication rec {
   makeWrapperArgs = [
     "--prefix PATH" ":" (lib.makeBinPath [ nixVersions.stable ])
   ];
-}nixVersions.stable
+}

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ python3.pkgs.buildPythonApplication rec {
     glibcLocales
     mypy
     # technically not a test input, but we need it for development in PATH
-    nixFlakes
+    nixVersions.stable
   ];
   checkPhase = ''
     echo -e "\x1b[32m## run black\x1b[0m"
@@ -27,6 +27,6 @@ python3.pkgs.buildPythonApplication rec {
     mypy --strict tex2nix
   '';
   makeWrapperArgs = [
-    "--prefix PATH" ":" (lib.makeBinPath [ nixFlakes ])
+    "--prefix PATH" ":" (lib.makeBinPath [ nixVersions.stable ])
   ];
-}
+}nixVersions.stable

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1614513358,
-        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1614934292,
-        "narHash": "sha256-TyKuSbTiUZcfrCx3G7ipLb2GzTGc/bf5qYPu8gGdkwI=",
+        "lastModified": 1664642704,
+        "narHash": "sha256-+t1N3pE2ofXS+t6rK0sVJwg4pCNW9VUQpQM/Rs9xXDI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d73b07d8746ed62cce744d8ed6a99a7398ec276",
+        "rev": "85106f3741545a818b16e9dd04232115f946948c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
A quick change that worked for making tex2nix compatible with the newest version of NixOS.