### PR TITLE
Update nixpkgs and fix deprecated nixFlakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,10 @@
 
 
 with pkgs;
+
+let
+  nixFlakes = nixVersions.stable;
+in
 python3.pkgs.buildPythonApplication rec {
   name = "tex2nix";
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1614513358,
-        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1614934292,
-        "narHash": "sha256-TyKuSbTiUZcfrCx3G7ipLb2GzTGc/bf5qYPu8gGdkwI=",
+        "lastModified": 1665143060,
+        "narHash": "sha256-+YvC++McgXlFiq7zagCY7sBiAMnqtdPRuS3dXRiWDhQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d73b07d8746ed62cce744d8ed6a99a7398ec276",
+        "rev": "15aaff6f640e02fe0b44b7e906f06fbcf5baf142",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The change from `nixFlakes` to `nixVersions.stable` breaks any build that uses `tex2nix` as the following flake input.

```nix
{
  inputs = {
    tex2nix = {
      url = github:Mic92/tex2nix;
      inputs.nixpkgs.follows = "nixpkgs";
    };
  };
}
```

A `nixpkgs` update was necessary to reflect this change.